### PR TITLE
Refactor

### DIFF
--- a/browser/js/user_dashboard/user_dashboard_state.js
+++ b/browser/js/user_dashboard/user_dashboard_state.js
@@ -9,10 +9,10 @@ app.config(function ($stateProvider) {
         resolve: {
             theUser: function(AuthService, $stateParams) {
                 return AuthService.getLoggedInUser()
-            },
-            theFollowersOfUser: function(UserFactory, $stateParams) {
-                return UserFactory.fetchAllFollowersForOneStreamer($stateParams.userId);
             }
+            // theFollowersOfUser: function(UserFactory, $stateParams) {
+            //     return UserFactory.fetchAllFollowersForOneStreamer($stateParams.userId);
+            // }
         }
     });
 


### PR DESCRIPTION
deleted the 'api method' for getting followers in the resolve method of user dashboard. This was preventing navigation to the dashboard, since we don't store that information in mongo.
